### PR TITLE
Expand on hover functionality

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -48,7 +48,9 @@ MyApplet.prototype = {
         this.settings.bindProperty(Settings.BindingDirection.IN, "show-hidden-player", "show_hidden_player", this._onDragEnd, null);
         ///to save icons_hide_by_user values in Cinnamon settings API
         this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL, "icons-hide-by-user", "icons_hide_by_user_settings",  this._loadIconsHideByUser, null);
-
+		///@mank319 whether or not to expand on hovering the expand button
+		this.settings.bindProperty(Settings.BindingDirection.IN, "expand-on-hover", "expand_on_hover", this._updateTray_button, null);
+		
         this.tray_icon_open =  new St.Icon();
         this.tray_icon_close =  new St.Icon();
         this.tray_button = new St.Button();
@@ -59,7 +61,7 @@ MyApplet.prototype = {
         this.tray_newHiddenIcon_Added = false;
 
         this.hidden_actor = new St.BoxLayout({});/// store hidden icons to keep them in bin box for "_onTrayIconRemoved" function
-
+		
         this.actual_hidden_role = [];
         this.actual_shown_role = [];
         this.added_icons =[];/// to fix icons are replaced by grey icons after dragging after dragging
@@ -482,6 +484,19 @@ MyApplet.prototype = {
                 }
             }
         }));
+		
+		///@mank319 Catch enter-event to expand on hovering the button
+		this.tray_button.connect('enter-event', Lang.bind(this, function(o, event){
+			/*  
+			 * Expand if the following criteria is met:
+			 * -expand on hover activated
+			 * -it is not expanded already (to avoid collapse on hover)
+			 * -panel edit mode is off
+			 */
+			if (this.expand_on_hover && !this.tray_isExpand && !global.settings.get_boolean('panel-edit-mode')) {
+             this._expandTray(this.expand_time);
+			}
+		}));
 
         let tray_icon_box = new St.Bin({ style_class: 'panel-status-button', reactive: true});
         tray_icon_box.add_actor(this.tray_button);

--- a/settings-schema.json
+++ b/settings-schema.json
@@ -72,7 +72,7 @@
     "type" : "checkbox",
     "default" : false,
     "description": "Expand on hover",
-    "tooltip": "Expand the Systemtray on hover instead of requiring a click"
+    "tooltip": "Expand the system tray on hover instead of requiring a click"
  },
  "icons-hide-by-user":{
     "type": "generic",

--- a/settings-schema.json
+++ b/settings-schema.json
@@ -68,6 +68,12 @@
     "description": "Show players support by sound applet",
     "tooltip": "Show Banshee, Tomahawk, Clementine and Amarok in system tray"
  },
+ "expand-on-hover" : {
+    "type" : "checkbox",
+    "default" : false,
+    "description": "Expand on hover",
+    "tooltip": "Expand the Systemtray on hover instad of requiring a click"
+ },
  "icons-hide-by-user":{
     "type": "generic",
     "default" : "[]",

--- a/settings-schema.json
+++ b/settings-schema.json
@@ -72,7 +72,7 @@
     "type" : "checkbox",
     "default" : false,
     "description": "Expand on hover",
-    "tooltip": "Expand the Systemtray on hover instad of requiring a click"
+    "tooltip": "Expand the Systemtray on hover instead of requiring a click"
  },
  "icons-hide-by-user":{
     "type": "generic",


### PR DESCRIPTION
Using my touchpad a lot I dislike the additional click needed for expanding the system tray.
This is why I implemented an 'expand on hover' functionality. It can be controlled via a settings entry and is turned off by default.
